### PR TITLE
17 refactor links in view templates

### DIFF
--- a/app/views/folders/_default_version_link.html.erb
+++ b/app/views/folders/_default_version_link.html.erb
@@ -1,12 +1,7 @@
 <div id="default-version-link" class="d-flex gap-1 justify-content-start flex-wrap">
 
   <% if version.link.attached? %>
-      <div>
-        <%= link_to "View", rails_blob_url(version.link, disposition: "preview"), target: "_blank", class: "btn btn-outline-primary flex-item" %>
-      </div>
-      <div>
-        <%= link_to "Download", rails_blob_url(version.link, disposition: "attachment"), class: "btn btn-outline-primary flex-item" %>
-      </div>
+    <%= render "versions/links", version: version %>
 
   <% else %>
     <div>

--- a/app/views/folders/_default_version_link.html.erb
+++ b/app/views/folders/_default_version_link.html.erb
@@ -7,9 +7,6 @@
       <div>
         <%= link_to "Download", rails_blob_url(version.link, disposition: "attachment"), class: "btn btn-outline-primary flex-item" %>
       </div>
-      <!--<div>-->
-        <%#= link_to "Share", rails_blob_url(version.link, host: request.base_url), target: "_blank", class: "btn btn-outline-primary" %>
-      <!--</div>-->
 
   <% else %>
     <div>

--- a/app/views/versions/_links.html.erb
+++ b/app/views/versions/_links.html.erb
@@ -1,0 +1,14 @@
+<div>
+  <% if version.link.attached? %>
+    <span>
+      <%= link_to "View", rails_blob_url(version.link, disposition: "inline"), target: "_blank", class: "btn btn-outline-primary" %>
+    </span>
+
+    <span>
+      <%= link_to "Download", rails_blob_url(version.link, disposition: "attachment"), class: "btn btn-outline-primary" %>
+    </span>
+
+  <% else %>
+    <p class="fst-italic">No file to download. Edit to add an attachment.</p>
+  <% end %>
+</div>

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -29,20 +29,10 @@
     </ul>
   </div>
 
-<div class="d-flex gap-1 justify-content-center m-2">
-  <% if version.link.attached? %>
-    <span>
-      <%= link_to "View", rails_blob_url(version.link, disposition: "inline"), target: "_blank", class: "btn btn-outline-primary" %>
-    </span>
+  <div class="d-flex gap-1 justify-content-center m-2">
+    <%= render "versions/links", version: version %>
+  </div>
 
-    <span>
-      <%= link_to "Download", rails_blob_url(version.link, disposition: "attachment"), class: "btn btn-outline-primary" %>
-    </span>
-
-  <% else %>
-    <p class="fst-italic">No file to download. Edit to add an attachment.</p>
-  <% end %>
-</div>
 
   <% if version.folder.default_version != version %>
     <div id="make-default" class="d-flex justify-content-center m-2">

--- a/app/views/versions/_version.html.erb
+++ b/app/views/versions/_version.html.erb
@@ -39,10 +39,6 @@
       <%= link_to "Download", rails_blob_url(version.link, disposition: "attachment"), class: "btn btn-outline-primary" %>
     </span>
 
-    <!--<span>-->
-      <%#= link_to "Share", rails_blob_url(version.link, host: request.base_url), target: "_blank", class: "btn btn-outline-primary" %>
-<!--    </span>-->
-
   <% else %>
     <p class="fst-italic">No file to download. Edit to add an attachment.</p>
   <% end %>


### PR DESCRIPTION
For each version, if there is an attachment, the application will provide the link to view in browser and download to computer/phone. Similar links would also appear on the main page next to each file to view and download the default version. I refactored those links into a partial to reduce redundancy, also make it easy for future update and maintenance. This is the pattern of component-based view templates.